### PR TITLE
Pull teleport-kube-agent upstream chart 9.1.2

### DIFF
--- a/charts/teleport-kube-agent/Chart.yaml
+++ b/charts/teleport-kube-agent/Chart.yaml
@@ -1,7 +1,7 @@
 name: teleport-kube-agent
 apiVersion: v2
-version: "9.0.3"
-appVersion: "9.0.3"
+version: "9.1.2"
+appVersion: "9.1.2"
 description: Teleport provides a secure SSH and Kubernetes remote access solution that doesn't get in the way.
 icon: https://goteleport.com/images/logos/logo-teleport-square.svg
 keywords:

--- a/charts/teleport-kube-agent/templates/deployment.yaml
+++ b/charts/teleport-kube-agent/templates/deployment.yaml
@@ -119,7 +119,7 @@ spec:
         {{- end }}
         {{- if .Values.extraEnv }}
         env:
-          {{- toYaml .Values.extraEnv | nindent 10 }}
+          {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"
@@ -148,6 +148,7 @@ spec:
           initialDelaySeconds: 5 # wait 5s for agent to start
           periodSeconds: 5 # poll health every 5s
           failureThreshold: 6 # consider agent unhealthy after 30s (6 * 5s)
+          timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /readyz
@@ -155,6 +156,7 @@ spec:
           initialDelaySeconds: 5 # wait 5s for agent to register
           periodSeconds: 5 # poll health every 5s
           failureThreshold: 12 # consider agent unhealthy after 60s (12 * 5s)
+          timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
 {{- if .Values.resources }}
         resources:
   {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/teleport-kube-agent/templates/statefulset.yaml
+++ b/charts/teleport-kube-agent/templates/statefulset.yaml
@@ -144,6 +144,7 @@ spec:
           initialDelaySeconds: 5 # wait 5s for agent to start
           periodSeconds: 5 # poll health every 5s
           failureThreshold: 6 # consider agent unhealthy after 30s (6 * 5s)
+          timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /readyz
@@ -151,6 +152,7 @@ spec:
           initialDelaySeconds: 5 # wait 5s for agent to register
           periodSeconds: 5 # poll health every 5s
           failureThreshold: 12 # consider agent unhealthy after 60s (12 * 5s)
+          timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
 {{- if .Values.resources }}
         resources:
   {{- toYaml .Values.resources | nindent 10 }}

--- a/charts/teleport-kube-agent/values.schema.json
+++ b/charts/teleport-kube-agent/values.schema.json
@@ -27,7 +27,8 @@
         "imagePullPolicy",
         "initContainers",
         "resources",
-        "tolerations"
+        "tolerations",
+        "probeTimeoutSeconds"
     ],
     "properties": {
         "authToken": {
@@ -328,6 +329,11 @@
             "$id": "#/properties/tolerations",
             "type": "array",
             "default": []
+        },
+        "probeTimeoutSeconds": {
+            "$id": "#/properties/probeTimeoutSeconds",
+            "type": "integer",
+            "default": 1
         }
     }
 }

--- a/charts/teleport-kube-agent/values.yaml
+++ b/charts/teleport-kube-agent/values.yaml
@@ -217,3 +217,7 @@ resources: {}
 # Tolerations for pod assignment
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
+
+# Timeouts for the readiness and liveness probes
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+probeTimeoutSeconds: 1


### PR DESCRIPTION
Pulled from `v9.1.2` tag https://github.com/gravitational/teleport/tree/v9.1.2/examples/chart/teleport-kube-agent