### PR TITLE
SpreadConstraints

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.8.2
+version: 1.9.0
 
 maintainers:
   - name: Dominic DePasquale

--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.0
+version: 2.0.0
 
 maintainers:
   - name: Dominic DePasquale

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -126,7 +126,7 @@ spec:
       {{- end }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
                   - key: app.kubernetes.io/name

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -126,16 +126,6 @@ spec:
       {{- end }}
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: app
-                      operator: In
-                      values:
-                        - {{ include "application-core.fullname" . }}
-                topologyKey: topology.kubernetes.io/zone
-              weight: 100
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
@@ -144,6 +134,16 @@ spec:
                     values:
                       - {{ include "application-core.fullname" . }}
               topologyKey: "kubernetes.io/hostname"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchExpressions:
+              - key: app
+                operator: In
+                values:
+                  - {{ include "application-core.fullname" . }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
-                  - key: app
+                  - key: app.kubernetes.io/name
                     operator: In
                     values:
                       - {{ include "application-core.fullname" . }}
@@ -140,7 +140,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchExpressions:
-              - key: app
+              - key: app.kubernetes.io/name
                 operator: In
                 values:
                   - {{ include "application-core.fullname" . }}


### PR DESCRIPTION
- switch to topologySpreadConstraints for zones
- bump chart
- fix the label that we match against
- don't require node antiaffinity so we don't block scheduling. (Sometimes we want to keep the node count low even if we _could_ build more)
