### PR TITLE
adds default property, converstionStrategy, and decodingStrategy

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.0
+version: 4.2.1
 
 maintainers:
   - name: Dominic DePasquale

--- a/charts/application-core/templates/externalsecret.yaml
+++ b/charts/application-core/templates/externalsecret.yaml
@@ -12,10 +12,10 @@ spec:
   {{- if .Values.externalSecret.data }}
   {{- range .Values.externalSecret.data}}
     - remoteRef:
-        conversionStrategy: {{ .remoteRef.conversionStrategy }}
-        decodingStrategy: {{ .remoteRef.decodingStrategy }}
+        conversionStrategy: {{ .remoteRef.conversionStrategy | default "Default" }}
+        decodingStrategy: {{ .remoteRef.decodingStrategy | default "None" }}
         key: {{ .remoteRef.key }}
-        property: {{ .remoteRef.property }}
+        property: {{ .remoteRef.property | default .remoteRef.key }}
       secretKey: {{ .secretKey }}
   {{- end }}
   {{- end }}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -112,6 +112,13 @@ extraSecrets: []
 
 externalSecret:
   enabled: false
+    # data:
+    # - remoteRef:
+    #     conversionStrategy: Default
+    #     decodingtrategy: None
+    #     key:
+    #     property: {{ .remoteRef.key }}
+    #   secretKey:
   data: []
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
makes `.key` the only required property when using `externalSecret.data`, and documents the defaults in values.yaml

presently, If left unset, the applied values will be the defaults and cause ArgoCD to constantly be out of sync. 