### PR TITLE
support most common usecase for mounting configmaps as files

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.1
+version: 4.2.2
 
 maintainers:
   - name: Dominic DePasquale

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -154,8 +154,15 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.emptyDir }}
           volumeMounts:
+          {{- range $volume := .Values.extraConfigMapVolumes }}
+            - mountPath: "{{ .mountPath }}"
+              name: "{{ .name }}"
+              {{- if .subPath }}
+              subPath: "{{ .subPath }}"
+              {{- end -}}
+          {{- end }}
+          {{- if .Values.emptyDir }}
             - mountPath: {{ .Values.emptyDir.mountPath }}
               name: emptydir-volume
           {{- end }}
@@ -190,8 +197,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.emptyDir }}
       volumes:
+      {{- range $volume := .Values.extraConfigMapVolumes }}
+      - name: {{ .name }}
+        configMap:
+          name: {{ .name }}
+      {{- end }}
+      {{- if .Values.emptyDir }}
       - name: emptydir-volume
         emptyDir:
           sizeLimit: {{ .Values.emptyDir.sizeLimit }}

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -158,9 +158,14 @@ spec:
           {{- range $volume := .Values.extraConfigMapVolumes }}
             - mountPath: "{{ .mountPath }}"
               name: "{{ .name }}"
+              {{- if eq .readOnly false }}
+              readOnly: false
+              {{- else }}
+              readOnly: true
+              {{- end }}
               {{- if .subPath }}
               subPath: "{{ .subPath }}"
-              {{- end -}}
+              {{- end }}
           {{- end }}
           {{- if .Values.emptyDir }}
             - mountPath: {{ .Values.emptyDir.mountPath }}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -110,6 +110,16 @@ env:
 extraConfigMaps: []
 extraSecrets: []
 
+# Mount ConfigMaps as files in the Deployment
+# Mount ca-bundle.pem from ca-cert-configmap to /etc/ssl/certs/ca-bundle.pem
+# - name: ca-cert-configmap
+#   mountPath: /etc/ssl/certs/ca-bundle.pem
+#   subPath: ca-bundle.pem
+# Mount all keys from ca-cert-configmap as files to /etc/ssl/certs
+# - name: ca-cert-configmap
+#   mountPath: /etc/ssl/certs/
+extraConfigMapVolumes: []
+
 externalSecret:
   enabled: false
     # data:


### PR DESCRIPTION
Externally managed configmaps can mount their keys as files