### PR TITLE
AppName

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.3
+version: 4.2.5
 
 maintainers:
   - name: Dominic DePasquale

--- a/charts/application-core/templates/_helpers.tpl
+++ b/charts/application-core/templates/_helpers.tpl
@@ -6,6 +6,17 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Build the env that gets injected into the deployments
+*/}}
+{{- define "application-core.env" -}}
+- name: APP_NAME
+  value: {{ .Values.appName | default (printf "%s-%s" .Release.Namespace .Release.Name) }}
+{{- if .Values.env }}
+{{ .Values.env | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -68,10 +68,8 @@ spec:
             - {{ . }}
           {{- end }}
           {{- end }}
-          {{- if or .Values.env }}
           env:
-            {{- .Values.env | toYaml | nindent 12 }}
-          {{- end }}
+          {{- include "application-core.env" . | nindent 12 }}
           {{- if or .Values.externalSecret.enabled .Values.configMap.enabled .Values.extraConfigMaps .Values.extraSecrets }}
           envFrom:
             {{- if .Values.configMap.enabled }}
@@ -142,10 +140,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
-          {{- if or .Values.env }}
           env:
-            {{- .Values.env | toYaml | nindent 12 }}
-          {{- end }}
+          {{- include "application-core.env"  . | nindent 12 }}
           {{- if or .Values.externalSecret.enabled .Values.configMap.enabled .Values.extraConfigMaps .Values.extraSecrets }}
           envFrom:
             {{- if .Values.configMap.enabled }}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -99,8 +99,12 @@ configMap:
 
 command: []
 
-env:
-  []
+# When unset APP_NAME will be set to {{.Release.Namespace}}-{{.Release.Name}}
+appName: ""
+
+env: []
+  # - name: FOO
+  #   value: bar
   # - name: FOO
   #   value: BAR
   # - name: BAZ


### PR DESCRIPTION
APP_NAME gets injected into the deployment by convention as {{.Release.Namespace }}-{{.Release.name}}

If `.Values.appName` is set, it will be overridden