### PR TITLE
rollouts

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,9 +16,9 @@ jobs:
         with:
           version: v3.13.2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.x
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --debug --validate-maintainers=false --lint-conf lintconf.yaml
+        run: ct lint --debug --validate-maintainers=false --lint-conf lintconf.yaml --target-branch master
 
       # Disabled until we update/fix the jenkins, ingress-nginx and vouch charts
       # - name: Create kind cluster

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch master
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch master
+          changed=$(ct list-changed --target-branch master)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi

--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.3.1
+version: 4.5.0
 
 
 maintainers:

--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.3.0
+version: 4.3.1
 
 
 maintainers:

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -1,5 +1,10 @@
+{{- if .Values.rollouts.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+{{- else }}
 apiVersion: apps/v1
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ include "application-core.fullname" . }}
   labels:
@@ -12,10 +17,41 @@ metadata:
 spec:
   revisionHistoryLimit: 2
   progressDeadlineSeconds: 300
+  {{- if .Values.rollouts.enabled }}
+  {{- if .Values.rolloutsDeploymentStrategy }}
+  {{- with .Values.rolloutsDeploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  strategy:
+    {{ .Values.rollouts.strategy }}:
+      activeService: {{ include "application-core.fullname" . }}
+      previewService: {{ include "application-core.fullname" . }}-preview
+      autoPromotionEnabled: {{ .Values.rollouts.autoPromotionEnabled | default true }}
+      {{- if .Values.rollouts.successRateTemplate.enabled }}
+      postPromotionAnalysis:
+        templates:
+          - templateName: {{ .Release.Name }}-success-rate
+        args:
+          - name: deployment
+            value: {{ include "application-core.fullname" . }}
+          - name: latest-hash
+            valueFrom:
+              podTemplateHashValue: "Latest"
+          - name: namespace
+            value: {{ .Release.Namespace }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+
+  {{- if ne (.Values.rollouts.enabled) true }}
   {{- with .Values.deploymentStrategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- end }}
+
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}

--- a/charts/application-core/templates/service-preview.yaml
+++ b/charts/application-core/templates/service-preview.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rollouts.successRateTemplate.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "application-core.fullname" . }}-preview
+  labels:
+    {{- include "application-core.labels" . | nindent 4 }}
+  annotations:
+    {{- include "application-core.annotations" $ | nindent 4 }}
+    {{- if .Values.service.annotations }}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector: {}
+{{- end -}}

--- a/charts/application-core/templates/success-rate.yaml
+++ b/charts/application-core/templates/success-rate.yaml
@@ -11,11 +11,11 @@ spec:
     - name: latest-hash
   metrics:
     - name: success-rate
-      interval: 30s
-      successCondition: result[0] >= 0.95
-      count: 10
-      failureLimit: 2
-      consecutiveSuccessLimit: 2
+      interval: {{ .Values.rollouts.successRateTemplate.interval  }}
+      successCondition: {{ .Values.rollouts.successRateTemplate.successCondition }}
+      count: {{ .Values.rollouts.successRateTemplate.count }}
+      failureLimit: {{ .Values.rollouts.successRateTemplate.failureLimit }}
+      consecutiveSuccessLimit: {{ .Values.rollouts.successRateTemplate.consecutiveSuccessLimit }}
       provider:
         prometheus:
           # TODO maybe make this an arg?

--- a/charts/application-core/templates/success-rate.yaml
+++ b/charts/application-core/templates/success-rate.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rollouts.enabled }}
+{{- if .Values.rollouts.successRateTemplate.enabled }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: {{ .Release.Name }}-success-rate
+spec:
+  args:
+    - name: deployment
+    - name: latest-hash
+  metrics:
+    - name: success-rate
+      interval: 30s
+      successCondition: result[0] >= 0.95
+      count: 10
+      failureLimit: 2
+      consecutiveSuccessLimit: 2
+      provider:
+        prometheus:
+          # TODO maybe make this an arg?
+          address: http://prometheus.linkerd-viz.svc.cluster.local:9090
+          query: |
+            sum(
+              irate(
+                response_total{classification="success", namespace="{{`{{args.namespace}}`}}", rollouts_pod_template_hash="{{`{{args.latest-hash}}`}}", direction="inbound"}[1m]
+                )
+              ) by (deployment) / sum(
+              irate(
+                response_total{namespace="{{`{{args.namespace}}`}}", rollouts_pod_template_hash="{{`{{args.latest-hash}}`}}", direction="inbound"}[1m])
+              ) by (deployment)
+
+{{- end }}
+{{- end }}

--- a/charts/application-core/templates/success-rate.yaml
+++ b/charts/application-core/templates/success-rate.yaml
@@ -18,8 +18,7 @@ spec:
       consecutiveSuccessLimit: {{ .Values.rollouts.successRateTemplate.consecutiveSuccessLimit }}
       provider:
         prometheus:
-          # TODO maybe make this an arg?
-          address: http://prometheus.linkerd-viz.svc.cluster.local:9090
+          address: {{ .Values.rollouts.successRateTemplate.address }}
           query: |
             sum(
               irate(

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -9,6 +9,7 @@ rollouts:
   strategy: blueGreen
   # Create a success-rate template and add it to postPromotionAnalysis
   # This is an opinionated template that uses the Linkerd metrics
+  # If rolloutsDeploymentStrategy is set, these defaults will be overridden
   successRateTemplate:
     enabled: true
     address: http://prometheus.monitoring.svc.cluster.local:9090

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -2,12 +2,44 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# When rollouts is enabled, we replace the Deployment Object with a Rollout Object
+rollouts:
+  enabled: false
+  # When strategy is blueGreen the rollout will be. Currently only supports blueGreen
+  strategy: blueGreen
+  # Create a success-rate template and add it to postPromotionAnalysis
+  # This is an opinionated template that uses the Linkerd metrics
+  successRateTemplate:
+    enabled: true
+
+
+# Strategy to use for the rollout. This is only used when rollouts is enabled.
+# Overrides the default strategy for the rollout.
+rolloutsDeploymentStrategy: {}
+  # blueGreen:
+  #   activeService: pro-api1
+  #   previewService: pro-api1-preview
+  #   autoPromotionEnabled: true
+  #   postPromotionAnalysis:
+  #     templates:
+  #       - templateName: success-rate
+  #     args:
+  #       - name: deployment
+  #         value: "pro-api1"
+  #       - name: latest-hash
+  #         valueFrom:
+  #           podTemplateHashValue: "Latest"
+  #       - name: namespace
+  #         value: "pro-monorepo-test-development"
+
+
+
 replicaCount: 1
 
 image:
   repository: nginx
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides  imagethe tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -11,6 +11,12 @@ rollouts:
   # This is an opinionated template that uses the Linkerd metrics
   successRateTemplate:
     enabled: true
+    address: http://prometheus.monitoring.svc.cluster.local:9090
+    interval: 30s
+    successCondition: result[0] >= 0.95
+    count: 10
+    failureLimit: 2
+    consecutiveSuccessLimit: 2
 
 
 # Strategy to use for the rollout. This is only used when rollouts is enabled.

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -43,7 +43,7 @@ replicaCount: 1
 image:
   repository: nginx
   pullPolicy: IfNotPresent
-  # Overrides  imagethe tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
 imagePullSecrets: []

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -19,7 +19,6 @@ rollouts:
     failureLimit: 2
     consecutiveSuccessLimit: 2
 
-
 # Strategy to use for the rollout. This is only used when rollouts is enabled.
 # Overrides the default strategy for the rollout.
 rolloutsDeploymentStrategy: {}
@@ -38,8 +37,6 @@ rolloutsDeploymentStrategy: {}
   #           podTemplateHashValue: "Latest"
   #       - name: namespace
   #         value: "pro-monorepo-test-development"
-
-
 
 replicaCount: 1
 


### PR DESCRIPTION
Initial take on rollouts in the helm chart. I presume that we're not going to get what the pre-baked templates and strategies should be so I provided a way to override the whole strategy block.

This pull request introduces significant changes to the Helm chart for the `application-core`. The main focus is on enabling and configuring Argo Rollouts for blue-green deployments and adding a success rate analysis template. The most important changes include updating the chart version, modifying deployment templates, adding a service preview template, and configuring the success rate analysis.

Key changes:

### Chart Version Update:
* Updated the chart version from `4.3.0` to `4.3.1` in `charts/application-core/Chart.yaml`.

### Deployment Template Modifications:
* Added conditional logic to switch between `Deployment` and `Rollout` objects based on the `rollouts.enabled` value in `charts/application-core/templates/deployment.yaml`.
* Introduced a new strategy section for Rollout objects, including configurations for blue-green deployments and post-promotion analysis in `charts/application-core/templates/deployment.yaml`.

### Service Preview Template:
* Added a new template for creating a preview service when the success rate template is enabled in `charts/application-core/templates/service-preview.yaml`.

### Success Rate Analysis Template:
* Added a new template for creating an AnalysisTemplate for success rate monitoring using Prometheus metrics in `charts/application-core/templates/success-rate.yaml`.

### Values Configuration:
* Introduced new configuration options for enabling rollouts, setting the strategy, and configuring the success rate template in `charts/application-core/values.yaml`.