### PR TITLE
Revert "default hi-res prometheus; use $__rate_interval"

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.5.3
+version: 4.5.2
 
 
 maintainers:

--- a/charts/application-core/templates/success-rate.yaml
+++ b/charts/application-core/templates/success-rate.yaml
@@ -23,11 +23,11 @@ spec:
           query: |
             sum(
               irate(
-                response_total{classification="success", namespace="{{`{{args.namespace}}`}}", rollouts_pod_template_hash="{{`{{args.latest-hash}}`}}", direction="inbound"}[$__rate_interval]
+                response_total{classification="success", namespace="{{`{{args.namespace}}`}}", rollouts_pod_template_hash="{{`{{args.latest-hash}}`}}", direction="inbound"}[1m]
                 )
               ) by (deployment) / sum(
               irate(
-                response_total{namespace="{{`{{args.namespace}}`}}", rollouts_pod_template_hash="{{`{{args.latest-hash}}`}}", direction="inbound"}[$__rate_interval])
+                response_total{namespace="{{`{{args.namespace}}`}}", rollouts_pod_template_hash="{{`{{args.latest-hash}}`}}", direction="inbound"}[1m])
               ) by (deployment)
 
 {{- end }}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -12,7 +12,7 @@ rollouts:
   # If rolloutsDeploymentStrategy is set, these defaults will be overridden
   successRateTemplate:
     enabled: true
-    address: http://prometheus-operated.monitoring.svc.cluster.local:9090
+    address: http://prometheus.monitoring.svc.cluster.local:9090
     interval: 30s
     successCondition: result[0] >= 0.95
     count: 10


### PR DESCRIPTION
```bad_data: invalid parameter "query": 3:136: parse error: bad number or duration syntax: ""```

This works in grafana, but not in Rollouts 