### PR TITLE
adds the ability to turn on github-deployment-hook within the chart

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.5.2
+version: 4.6.0
 
 
 maintainers:

--- a/charts/application-core/templates/_helpers.tpl
+++ b/charts/application-core/templates/_helpers.tpl
@@ -100,3 +100,36 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Build the Env vars that get sent to github-deployment-hook
+*/}}
+{{- define "application-core.github-deployment-hook.env" }}
+- name: ENVIRONMENT_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.githubDeploymentHook.configMapName }}
+      key: {{ .Values.githubDeploymentHook.envUrlKey }}
+- name: LOG_URL
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.githubDeploymentHook.configMapName }}
+      key: {{ .Values.githubDeploymentHook.logUrlKey }}
+- name: ENVIRONMENT_NAME
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.githubDeploymentHook.configMapName }}
+      key: {{ .Values.githubDeploymentHook.environmentNameKey }}
+- name: GITHUB_REF
+  valueFrom:
+    configMapKeyRef:
+      name: {{ .Values.githubDeploymentHook.configMapName }}
+      key: {{ .Values.githubDeploymentHook.githubRefKey }}
+- name: GITHUB_REPO
+  value: {{ .Values.githubDeploymentHook.githubRepo }}
+- name: GITHUB_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.githubDeploymentHook.secretName }}
+      key: {{ .Values.githubDeploymentHook.githubTokenSecretKey }}
+{{- end }}

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -29,13 +29,7 @@ spec:
       activeService: {{ include "application-core.fullname" . }}
       previewService: {{ include "application-core.fullname" . }}-preview
       autoPromotionEnabled: {{ .Values.rollouts.autoPromotionEnabled | default true }}
-      {{- if .Values.rollouts.prePromotionAnalysis.enabled }}
-      prePromotionAnalysis:
-        templates:
-          {{- toYaml .Values.rollouts.prePromotionAnalysis.templates | nindent 10 }}
-        args:
-          {{- toYaml .Values.rollouts.prePromotionAnalysis.args | nindent 10 }}
-      {{- end }}
+      {{- if .Values.rollouts.successRateTemplate.enabled }}
       postPromotionAnalysis:
         templates:
           - templateName: {{ .Release.Name }}-success-rate
@@ -47,6 +41,7 @@ spec:
               podTemplateHashValue: "Latest"
           - name: namespace
             value: {{ .Release.Namespace }}
+      {{- end }}
   {{- end }}
   {{- end }}
 

--- a/charts/application-core/templates/deployment.yaml
+++ b/charts/application-core/templates/deployment.yaml
@@ -29,7 +29,13 @@ spec:
       activeService: {{ include "application-core.fullname" . }}
       previewService: {{ include "application-core.fullname" . }}-preview
       autoPromotionEnabled: {{ .Values.rollouts.autoPromotionEnabled | default true }}
-      {{- if .Values.rollouts.successRateTemplate.enabled }}
+      {{- if .Values.rollouts.prePromotionAnalysis.enabled }}
+      prePromotionAnalysis:
+        templates:
+          {{- toYaml .Values.rollouts.prePromotionAnalysis.templates | nindent 10 }}
+        args:
+          {{- toYaml .Values.rollouts.prePromotionAnalysis.args | nindent 10 }}
+      {{- end }}
       postPromotionAnalysis:
         templates:
           - templateName: {{ .Release.Name }}-success-rate
@@ -41,7 +47,6 @@ spec:
               podTemplateHashValue: "Latest"
           - name: namespace
             value: {{ .Release.Namespace }}
-      {{- end }}
   {{- end }}
   {{- end }}
 

--- a/charts/application-core/templates/github-deployment-hook/post-sync-hook.yaml
+++ b/charts/application-core/templates/github-deployment-hook/post-sync-hook.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.githubDeploymentHook.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-post-sync-hook
+  annotations:
+    opengov.com/argocd-hook: 'true'
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    spec:
+      containers:
+        - name: github-deployment-hook
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          image: {{ .Values.githubDeploymentHook.image }}
+          env:
+            {{ include "application-core.github-deployment-hook.env" . | indent 12 }}
+            - name: DEPLOYMENT_STATE
+              value: 'success'
+          resources:
+            requests:
+              memory: '64Mi'
+              cpu: '50m'
+            limits:
+              memory: '64Mi'
+      restartPolicy: Never
+{{- end }}

--- a/charts/application-core/templates/github-deployment-hook/sync-fail-hook.yaml
+++ b/charts/application-core/templates/github-deployment-hook/sync-fail-hook.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.githubDeploymentHook.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-sync-fail-hook
+  annotations:
+    opengov.com/argocd-hook: 'true'
+    argocd.argoproj.io/hook: SyncFail
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    spec:
+      containers:
+        - name: github-deployment-hook
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          image: {{ .Values.githubDeploymentHook.image }}
+          env:
+            {{ include "application-core.github-deployment-hook.env" . | indent 12 }}
+            - name: DEPLOYMENT_STATE
+              value: 'failure'
+          resources:
+            requests:
+              memory: '64Mi'
+              cpu: '50m'
+            limits:
+              memory: '64Mi'
+      restartPolicy: Never
+{{- end }}

--- a/charts/application-core/templates/github-deployment-hook/sync-hook.yaml
+++ b/charts/application-core/templates/github-deployment-hook/sync-hook.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.githubDeploymentHook.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-sync-hook
+  annotations:
+    opengov.com/argocd-hook: 'true'
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    spec:
+      containers:
+        - name: github-deployment-hook
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          image: {{ .Values.githubDeploymentHook.image }}
+          env:
+            {{ include "application-core.github-deployment-hook.env" . | indent 12 }}
+            - name: DEPLOYMENT_STATE
+              value: 'in_progress'
+          resources:
+            requests:
+              memory: '64Mi'
+              cpu: '50m'
+            limits:
+              memory: '64Mi'
+      restartPolicy: Never
+{{- end }}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -19,6 +19,22 @@ rollouts:
     failureLimit: 2
     consecutiveSuccessLimit: 2
 
+# Adds a Job that will run to update the Github Deployment Status
+githubDeploymentHook:
+  image: 918073871806.dkr.ecr.us-west-2.amazonaws.com/pro-github-deployment-hook:v0.1.1
+  enabled: false
+  githubRepo: 'opengov/repo'
+  # ConfigMapName that stores the environment name, log url, and github ref
+  # The keys in the configMap are used to set the environment variables
+  configMapName: github-deployment-hook
+  logUrlKey: log_url
+  environmentNameKey: environment
+  githubRefKey: ref
+  envUrlKey: env_url
+  # Secret that stores the Github Token
+  secretName: github-deployment-hook
+  githubTokenSecretKey: GITHUB_TOKEN
+
 # Strategy to use for the rollout. This is only used when rollouts is enabled.
 # Overrides the default strategy for the rollout.
 rolloutsDeploymentStrategy: {}


### PR DESCRIPTION
adds the ability to turn on the github deployment hooks within our helm chart. this allows us to easily customize things like it's metadata.name, and DRY up the config.