### PR TITLE
og-application: Add Gateway API support (Gateway, HTTPRoute, Referenc…

### DIFF
--- a/charts/og-application/Chart.yaml
+++ b/charts/og-application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 
 maintainers:
   - name: XOPS Platform Team

--- a/charts/og-application/templates/agentgateway-policy.yaml
+++ b/charts/og-application/templates/agentgateway-policy.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.agentgatewayPolicy.enabled -}}
+{{- $fullName := include "og-application.fullname" . -}}
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: {{ .Values.agentgatewayPolicy.name | default (printf "body-size-%s" $fullName) }}
+  namespace: {{ .Values.agentgatewayPolicy.namespace | default "management" }}
+  labels:
+    {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.agentgatewayPolicy.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- include "og-application.annotations" . | nindent 4 }}
+  {{- with .Values.agentgatewayPolicy.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    {{- range .Values.agentgatewayPolicy.targetRefs }}
+    - group: {{ .group | default "gateway.networking.k8s.io" }}
+      kind: {{ .kind | default "HTTPRoute" }}
+      name: {{ .name | default $fullName }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.agentgatewayPolicy.frontend }}
+  frontend:
+    {{- toYaml .Values.agentgatewayPolicy.frontend | nindent 4 }}
+  {{- end }}
+  {{- if .Values.agentgatewayPolicy.backend }}
+  backend:
+    {{- toYaml .Values.agentgatewayPolicy.backend | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/og-application/templates/agentgateway-policy.yaml
+++ b/charts/og-application/templates/agentgateway-policy.yaml
@@ -34,4 +34,8 @@ spec:
   backend:
     {{- toYaml .Values.agentgatewayPolicy.backend | nindent 4 }}
   {{- end }}
+  {{- if .Values.agentgatewayPolicy.retry }}
+  retry:
+    {{- toYaml .Values.agentgatewayPolicy.retry | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/og-application/templates/httproute.yaml
+++ b/charts/og-application/templates/httproute.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.httproute.enabled -}}
 {{- $fullName := include "og-application.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
+{{- $releaseNamespace := .Release.Namespace -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $fullName }}
+  name: {{ .Values.httproute.name | default $fullName }}
   namespace: {{ .Values.httproute.namespace | default .Release.Namespace }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
@@ -40,7 +41,7 @@ spec:
         {{- toYaml .backendRefs | nindent 8 }}
         {{- else }}
         - name: {{ .serviceName | default $fullName }}
-          namespace: {{ .serviceNamespace | default $.Release.Namespace }}
+          namespace: {{ .serviceNamespace | default $releaseNamespace }}
           port: {{ .servicePort | default $svcPort }}
           {{- if .weight }}
           weight: {{ .weight }}
@@ -51,4 +52,59 @@ spec:
         {{- toYaml .timeouts | nindent 8 }}
       {{- end }}
     {{- end }}
+{{- end }}
+{{- range .Values.httproutes }}
+{{- if .enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .name | required "httproutes[].name is required" }}
+  namespace: {{ .namespace | default $.Release.Namespace }}
+  labels:
+    {{- include "og-application.labels" $ | nindent 4 }}
+  {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- include "og-application.annotations" $ | nindent 4 }}
+  {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .rules }}
+    - {{- if .matches }}
+      matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ .serviceName | required "backendRefs serviceName is required when backendRefs not specified" }}
+          namespace: {{ .serviceNamespace | default $.Release.Namespace }}
+          port: {{ .servicePort | required "backendRefs servicePort is required when backendRefs not specified" }}
+          {{- if .weight }}
+          weight: {{ .weight }}
+          {{- end }}
+        {{- end }}
+      {{- if .timeouts }}
+      timeouts:
+        {{- toYaml .timeouts | nindent 8 }}
+      {{- end }}
+    {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/og-application/templates/httproute.yaml
+++ b/charts/og-application/templates/httproute.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.httproute.enabled -}}
+{{- $fullName := include "og-application.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Values.httproute.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    {{- include "og-application.annotations" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httproute.rules }}
+    - {{- if .matches }}
+      matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- end }}
+      {{- if .filters }}
+      filters:
+        {{- toYaml .filters | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ .serviceName | default $fullName }}
+          namespace: {{ .serviceNamespace | default $.Release.Namespace }}
+          port: {{ .servicePort | default $svcPort }}
+          {{- if .weight }}
+          weight: {{ .weight }}
+          {{- end }}
+        {{- end }}
+      {{- if .timeouts }}
+      timeouts:
+        {{- toYaml .timeouts | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -169,6 +169,76 @@ ingress:
           pathType: ImplementationSpecific
   tls: []
 
+# Gateway API HTTPRoute configuration
+# HTTPRoute connects your application to an existing Gateway in the cluster
+# (Gateway is managed by platform team and already deployed)
+#
+# Example configuration:
+#   httproute:
+#     enabled: true
+#     namespace: my-app  # Same as your service namespace
+#     parentRefs:
+#       - name: cpa-gateway  # Existing Gateway in cluster
+#         namespace: kgateway-system
+#     hostnames:
+#       - my-app.integration.engops.opengov.zone
+#     rules:
+#       - matches:
+#           - path:
+#               type: PathPrefix
+#               value: /
+#         timeouts:
+#           request: 60s
+#           backendRequest: 55s
+httproute:
+httproute:
+  enabled: false
+  # HTTPRoute namespace (default: Release.Namespace)
+  namespace: ""
+  # Additional labels for HTTPRoute resource
+  labels: {}
+  # Additional annotations for HTTPRoute resource
+  annotations: {}
+  # Parent Gateway references (required when enabled)
+  # Example:
+  # parentRefs:
+  #   - name: my-gateway
+  #     namespace: gateway-system
+  #   - name: external-gateway
+  #     namespace: gateway-system
+  #     sectionName: https
+  parentRefs: []
+  # Hostnames for routing (optional, can be inherited from Gateway)
+  hostnames: []
+  # Routing rules (required when enabled)
+  # Example:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /api
+  #     backendRefs:
+  #       - name: api-service
+  #         port: 8080
+  #         weight: 90
+  #       - name: api-service-canary
+  #         port: 8080
+  #         weight: 10
+  #     timeouts:
+  #       request: 60s
+  #       backendRequest: 55s
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /
+  #     filters:
+  #       - type: RequestRedirect
+  #         requestRedirect:
+  #           path:
+  #             type: ReplacePrefixMatch
+  #             replacePrefixMatch: /v2
+  rules: []
+
 configMap:
   enabled: true
   data: {}

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -178,8 +178,11 @@ ingress:
 #     enabled: true
 #     namespace: platform  # Your app namespace (same as service)
 #     parentRefs:
-#       - name: staging-gateway  # Existing Gateway in cluster (staging/integration)
-#         namespace: management  # Gateway namespace (management for AgentGateway)
+#       - name: staging-gateway      # Use gateway name based on environment:
+#         namespace: management      # - development-gateway (for dev environment)
+#                                    # - integration-gateway (for integration environment)
+#                                    # - staging-gateway (for staging environment)
+#                                    # - production-gateway (for production environment)
 #     rules:
 #       - matches:
 #           - path:
@@ -245,8 +248,9 @@ httproute:
   #
   # Single gateway (most common):
   # parentRefs:
-  #   - name: staging-gateway
-  #     namespace: management
+  #   - name: staging-gateway        # Gateway name based on environment:
+  #     namespace: management        # development-gateway, integration-gateway,
+  #                                  # staging-gateway, production-gateway
   #
   # Multiple gateways (route attaches to both):
   # parentRefs:

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -173,23 +173,62 @@ ingress:
 # HTTPRoute connects your application to an existing Gateway in the cluster
 # (Gateway is managed by platform team and already deployed)
 #
-# Example configuration:
+# Example - Simple configuration:
 #   httproute:
 #     enabled: true
-#     namespace: my-app  # Same as your service namespace
+#     namespace: platform  # Your app namespace (same as service)
 #     parentRefs:
-#       - name: cpa-gateway  # Existing Gateway in cluster
-#         namespace: kgateway-system
-#     hostnames:
-#       - my-app.integration.engops.opengov.zone
+#       - name: staging-gateway  # Existing Gateway in cluster (staging/integration)
+#         namespace: management  # Gateway namespace (management for AgentGateway)
 #     rules:
 #       - matches:
 #           - path:
 #               type: PathPrefix
 #               value: /
+#         backendRefs:
+#           - name: my-app
+#             port: 8080
+#             namespace: platform
+#
+# Example - Multiple paths (like ace-service):
+#   httproute:
+#     enabled: true
+#     namespace: platform
+#     parentRefs:
+#       - name: staging-gateway
+#         namespace: management
+#     rules:
+#       - matches:
+#           - path:
+#               type: PathPrefix
+#               value: /auth/users
+#         backendRefs:
+#           - name: my-app
+#             port: 80
+#             namespace: platform
 #         timeouts:
-#           request: 60s
-#           backendRequest: 55s
+#           request: "900s"
+#       - matches:
+#           - path:
+#               type: PathPrefix
+#               value: /api/users
+#         backendRefs:
+#           - name: my-app
+#             port: 80
+#             namespace: platform
+#         timeouts:
+#           request: "900s"
+#
+# Example - Multiple parent gateways:
+#   httproute:
+#     parentRefs:
+#       - name: staging-gateway      # Attach to staging gateway
+#         namespace: management
+#       - name: internal-gateway     # Also attach to internal gateway
+#         namespace: management
+#
+# Note: parentRefs is a list - HTTPRoute can attach to multiple Gateways.
+# The template uses 'toYaml' to copy the list structure directly to the manifest.
 httproute:
   enabled: false
   # HTTPRoute name (default: release name)
@@ -201,9 +240,19 @@ httproute:
   # Additional annotations for HTTPRoute resource
   annotations: {}
   # Parent Gateway references (required when enabled)
-  # Example:
+  # This is a YAML list that maps directly to HTTPRoute spec.parentRefs
+  # Each item in the list becomes a Gateway that this HTTPRoute attaches to
+  #
+  # Single gateway (most common):
   # parentRefs:
   #   - name: staging-gateway
+  #     namespace: management
+  #
+  # Multiple gateways (route attaches to both):
+  # parentRefs:
+  #   - name: staging-gateway
+  #     namespace: management
+  #   - name: integration-gateway
   #     namespace: management
   parentRefs: []
   # Hostnames for routing (optional, can be inherited from Gateway)
@@ -339,13 +388,22 @@ httproute:
   rules: []
 
 # Multiple HTTPRoutes (for separate internal/external routing)
-# Example:
+# Use this when you need SEPARATE HTTPRoute resources for different gateways.
+#
+# When to use:
+# - Different gateways for internal vs external (security boundary)
+# - Separate HTTPRoutes for public API vs admin API
+#
+# Note: For multiple paths on the SAME gateway, use multiple rules in httproute.rules[]
+# (See ace-service example above with multiple rules in one HTTPRoute)
+#
+# Example - Separate HTTPRoutes for external/internal gateways:
 # httproutes:
-#   - name: external-routes
+#   - name: my-app-external
 #     enabled: true
 #     namespace: platform
 #     parentRefs:
-#       - name: external-gateway
+#       - name: staging-gateway  # External/public gateway
 #         namespace: management
 #     rules:
 #       - matches:
@@ -353,22 +411,22 @@ httproute:
 #               type: PathPrefix
 #               value: /api/public
 #         backendRefs:
-#           - name: my-service
+#           - name: my-app
 #             port: 8080
 #             namespace: platform
-#   - name: internal-routes
+#   - name: my-app-internal
 #     enabled: true
 #     namespace: platform
 #     parentRefs:
-#       - name: internal-gateway
+#       - name: internal-gateway  # Internal/admin gateway
 #         namespace: management
 #     rules:
 #       - matches:
 #           - path:
 #               type: PathPrefix
-#               value: /api/internal
+#               value: /api/admin
 #         backendRefs:
-#           - name: my-service
+#           - name: my-app
 #             port: 8080
 #             namespace: platform
 httproutes: []

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -238,6 +238,48 @@ httproute:
   #             replacePrefixMatch: /v2
   rules: []
 
+# AgentgatewayPolicy: Custom policy for AgentGateway (body size, timeouts, etc.)
+# Only applies when using AgentGateway as your Gateway implementation
+# Example configuration:
+#   agentgatewayPolicy:
+#     enabled: true
+#     namespace: management  # Where Gateway lives
+#     targetRefs:
+#       - name: my-app  # HTTPRoute name to apply policy to
+#         namespace: platform  # HTTPRoute namespace
+#     frontend:
+#       http:
+#         maxBufferSize: 3145728  # 3MB max body size
+agentgatewayPolicy:
+  enabled: false
+  # Policy name (default: body-size-{fullname})
+  name: ""
+  # Policy namespace (default: management - where Gateway lives)
+  namespace: management
+  # Additional labels for AgentgatewayPolicy resource
+  labels: {}
+  # Additional annotations for AgentgatewayPolicy resource
+  annotations: {}
+  # Target HTTPRoute references (required when enabled)
+  # Example:
+  # targetRefs:
+  #   - name: my-app
+  #     namespace: platform
+  targetRefs: []
+  # Frontend policy (max body size, etc.)
+  # Example:
+  # frontend:
+  #   http:
+  #     maxBufferSize: 3145728  # 3MB
+  #     requestTimeout: 300s
+  frontend: {}
+  # Backend policy (connection timeouts, etc.)
+  # Example:
+  # backend:
+  #   http:
+  #     connectionTimeout: 10s
+  backend: {}
+
 configMap:
   enabled: true
   data: {}

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -191,7 +191,6 @@ ingress:
 #           request: 60s
 #           backendRequest: 55s
 httproute:
-httproute:
   enabled: false
   # HTTPRoute namespace (default: Release.Namespace)
   namespace: ""

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -192,6 +192,8 @@ ingress:
 #           backendRequest: 55s
 httproute:
   enabled: false
+  # HTTPRoute name (default: release name)
+  name: ""
   # HTTPRoute namespace (default: Release.Namespace)
   namespace: ""
   # Additional labels for HTTPRoute resource
@@ -201,55 +203,212 @@ httproute:
   # Parent Gateway references (required when enabled)
   # Example:
   # parentRefs:
-  #   - name: my-gateway
-  #     namespace: gateway-system
-  #   - name: external-gateway
-  #     namespace: gateway-system
-  #     sectionName: https
+  #   - name: staging-gateway
+  #     namespace: management
   parentRefs: []
   # Hostnames for routing (optional, can be inherited from Gateway)
   hostnames: []
   # Routing rules (required when enabled)
-  # Example:
+  #
+  # Basic path routing:
   # rules:
   #   - matches:
   #       - path:
   #           type: PathPrefix
   #           value: /api
   #     backendRefs:
-  #       - name: api-service
+  #       - name: my-service
   #         port: 8080
-  #         weight: 90
-  #       - name: api-service-canary
-  #         port: 8080
-  #         weight: 10
+  #         namespace: platform
   #     timeouts:
-  #       request: 60s
-  #       backendRequest: 55s
+  #       request: "900s"
+  #
+  # Method-based routing:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /api/users
+  #         method: POST
+  #     backendRefs:
+  #       - name: user-service
+  #         port: 8080
+  #
+  # Query parameter matching:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /api
+  #         queryParams:
+  #           - name: version
+  #             value: v2
+  #
+  # Header-based routing:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /api
+  #         headers:
+  #           - name: X-API-Version
+  #             value: v2
+  #
+  # Traffic splitting (canary/blue-green):
+  # rules:
   #   - matches:
   #       - path:
   #           type: PathPrefix
   #           value: /
+  #     backendRefs:
+  #       - name: stable-service
+  #         port: 8080
+  #         weight: 90
+  #       - name: canary-service
+  #         port: 8080
+  #         weight: 10
+  #
+  # Request header modification:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /api
   #     filters:
-  #       - type: RequestRedirect
-  #         requestRedirect:
+  #       - type: RequestHeaderModifier
+  #         requestHeaderModifier:
+  #           add:
+  #             - name: X-Custom-Header
+  #               value: custom-value
+  #           set:
+  #             - name: X-Request-ID
+  #               value: generated-id
+  #           remove:
+  #             - X-Internal-Header
+  #
+  # Response header modification:
+  # rules:
+  #   - filters:
+  #       - type: ResponseHeaderModifier
+  #         responseHeaderModifier:
+  #           add:
+  #             - name: X-Response-Time
+  #               value: "100ms"
+  #           remove:
+  #             - Server
+  #
+  # URL rewrite (path prefix replacement):
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /v1
+  #     filters:
+  #       - type: URLRewrite
+  #         urlRewrite:
   #           path:
   #             type: ReplacePrefixMatch
   #             replacePrefixMatch: /v2
+  #
+  # Request redirect:
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /old-path
+  #     filters:
+  #       - type: RequestRedirect
+  #         requestRedirect:
+  #           scheme: https
+  #           statusCode: 301
+  #           path:
+  #             type: ReplacePrefixMatch
+  #             replacePrefixMatch: /new-path
+  #
+  # Request mirroring (traffic shadowing):
+  # rules:
+  #   - backendRefs:
+  #       - name: production-service
+  #         port: 8080
+  #     filters:
+  #       - type: RequestMirror
+  #         requestMirror:
+  #           backendRef:
+  #             name: test-service
+  #             port: 8080
   rules: []
 
-# AgentgatewayPolicy: Custom policy for AgentGateway (body size, timeouts, etc.)
+# Multiple HTTPRoutes (for separate internal/external routing)
+# Example:
+# httproutes:
+#   - name: external-routes
+#     enabled: true
+#     namespace: platform
+#     parentRefs:
+#       - name: external-gateway
+#         namespace: management
+#     rules:
+#       - matches:
+#           - path:
+#               type: PathPrefix
+#               value: /api/public
+#         backendRefs:
+#           - name: my-service
+#             port: 8080
+#             namespace: platform
+#   - name: internal-routes
+#     enabled: true
+#     namespace: platform
+#     parentRefs:
+#       - name: internal-gateway
+#         namespace: management
+#     rules:
+#       - matches:
+#           - path:
+#               type: PathPrefix
+#               value: /api/internal
+#         backendRefs:
+#           - name: my-service
+#             port: 8080
+#             namespace: platform
+httproutes: []
+
+# AgentgatewayPolicy: Custom policy for AgentGateway (body size, timeouts, retries, etc.)
 # Only applies when using AgentGateway as your Gateway implementation
-# Example configuration:
+#
+# Basic body size configuration:
 #   agentgatewayPolicy:
 #     enabled: true
-#     namespace: management  # Where Gateway lives
+#     namespace: management
 #     targetRefs:
-#       - name: my-app  # HTTPRoute name to apply policy to
-#         namespace: platform  # HTTPRoute namespace
+#       - name: my-app
+#         namespace: platform
 #     frontend:
 #       http:
-#         maxBufferSize: 3145728  # 3MB max body size
+#         maxBufferSize: 3145728  # 3MB
+#
+# Advanced configuration with retries and timeouts:
+#   agentgatewayPolicy:
+#     enabled: true
+#     targetRefs:
+#       - name: my-app
+#         namespace: platform
+#     frontend:
+#       http:
+#         maxBufferSize: 10485760  # 10MB for large uploads
+#         requestTimeout: 300s
+#         idleTimeout: 60s
+#     backend:
+#       http:
+#         connectionTimeout: 10s
+#         maxConnections: 1000
+#     retry:
+#       attempts: 3
+#       backoff: 1s
+#       retryOn:
+#         - "5xx"
+#         - "reset"
+#         - "connect-failure"
 agentgatewayPolicy:
   enabled: false
   # Policy name (default: body-size-{fullname})
@@ -265,20 +424,36 @@ agentgatewayPolicy:
   # targetRefs:
   #   - name: my-app
   #     namespace: platform
+  #   - name: my-app-internal
+  #     namespace: platform
   targetRefs: []
-  # Frontend policy (max body size, etc.)
-  # Example:
-  # frontend:
+  # Frontend policy (client-facing settings)
+  # Common options:
   #   http:
-  #     maxBufferSize: 3145728  # 3MB
-  #     requestTimeout: 300s
+  #     maxBufferSize: 3145728        # Max request body size (bytes)
+  #     requestTimeout: 300s          # Total request timeout
+  #     idleTimeout: 60s              # Connection idle timeout
+  #     maxRequestHeaderSize: 8192    # Max header size (bytes)
   frontend: {}
-  # Backend policy (connection timeouts, etc.)
-  # Example:
-  # backend:
+  # Backend policy (upstream connection settings)
+  # Common options:
   #   http:
-  #     connectionTimeout: 10s
+  #     connectionTimeout: 10s        # Backend connection timeout
+  #     maxConnections: 1000          # Max connections to backend
+  #     maxPendingRequests: 1024      # Max pending requests
+  #     http2MaxRequests: 100         # Max HTTP/2 requests
   backend: {}
+  # Retry policy
+  # Example:
+  #   retry:
+  #     attempts: 3
+  #     backoff: 1s
+  #     retryOn:
+  #       - "5xx"
+  #       - "reset"
+  #       - "connect-failure"
+  #       - "retriable-4xx"
+  retry: {}
 
 configMap:
   enabled: true


### PR DESCRIPTION
…eGrant)

Add Kubernetes Gateway API resource templates to support modern gateway-based routing:

- Add gateway.yaml template for Gateway resource
- Add httproute.yaml template for HTTPRoute resource
- Add referencegrant.yaml template for cross-namespace Service access
- Update values.yaml with comprehensive Gateway API configuration
- Bump chart version to 1.0.11

Gateway API provides declarative, role-oriented routing that separates infrastructure concerns (Gateway) from application routing (HTTPRoute).

All resources are disabled by default for backward compatibility.

Related: CLOUD-6533