### PR TITLE
[CLOUD-6686] og-application: add migration Job template (ArgoCD PreSync hook)

### DIFF
--- a/charts/og-application/Chart.yaml
+++ b/charts/og-application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 
 maintainers:
   - name: XOPS Platform Team

--- a/charts/og-application/Chart.yaml
+++ b/charts/og-application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 maintainers:
   - name: XOPS Platform Team

--- a/charts/og-application/templates/migration-job.yaml
+++ b/charts/og-application/templates/migration-job.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "og-application.fullname" . }}-migrate
+  labels:
+    {{- include "og-application.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: {{ .Values.migrationJob.hook | default "PreSync" }}
+    argocd.argoproj.io/hook-delete-policy: {{ .Values.migrationJob.hookDeletePolicy | default "BeforeHookCreation" }}
+    {{- with .Values.migrationJob.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migrationJob.backoffLimit | default 2 }}
+  ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished | default 3600 }}
+  {{- if .Values.migrationJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.migrationJob.activeDeadlineSeconds }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "og-application.fullname" . }}-migrate
+        app.kubernetes.io/part-of: {{ include "og-application.fullname" . }}
+    spec:
+      restartPolicy: {{ .Values.migrationJob.restartPolicy | default "Never" }}
+      serviceAccountName: {{ include "og-application.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.migrationJob.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.migrationJob.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.migrationJob.env .Values.migrationJob.envFrom .Values.configMap.enabled .Values.externalSecret.enabled }}
+          env:
+            {{- with .Values.migrationJob.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.configMap.enabled }}
+            - configMapRef:
+                name: {{ include "og-application.fullname" . }}-cm
+            {{- end }}
+            {{- if .Values.externalSecret.enabled }}
+            - secretRef:
+                name: {{ include "og-application.fullname" . }}-secrets
+            {{- end }}
+            {{- with .Values.migrationJob.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.migrationJob.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+{{- end }}

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -756,34 +756,79 @@ cronJob:
   podAnnotations: {}
 
 # Migration Job configuration (ArgoCD PreSync hook)
-# Runs a one-time Job before the Deployment is updated — typically for DB migrations.
-# Uses the same image as the main deployment. ConfigMap and ExternalSecret are
-# automatically mounted via envFrom when enabled.
-# Example:
+# Runs a one-time Job BEFORE the Deployment is updated — typically for DB migrations.
+#
+# How it works:
+#   - Uses the SAME image as the main Deployment (image.repository:image.tag).
+#   - Reuses the same ServiceAccount, podSecurityContext, and container securityContext.
+#   - When configMap.enabled=true,  the ConfigMap is auto-mounted via envFrom.
+#   - When externalSecret.enabled=true, the ExternalSecret is auto-mounted via envFrom.
+#   - ArgoCD runs it as a PreSync hook and deletes it before the next sync.
+#
+# REQUIRED when enabled: you MUST set `command` (and/or `args`).
+# If you leave command empty, the Job will start the image's default ENTRYPOINT/CMD —
+# which for an app image means it boots the application instead of running a migration.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Example 1 — simple npm script (Node service):
 #   migrationJob:
 #     enabled: true
 #     command:
 #       - /bin/sh
 #       - -c
 #       - npm run migrate
+#
+# Example 2 — bun monorepo, needs to cd into a sub-package first:
+#   migrationJob:
+#     enabled: true
+#     command:
+#       - /bin/sh
+#       - -c
+#       - cd /app/packages/repo && bun run --conditions @opengov/bed-source scripts/migrate.ts
 #     env:
 #       - name: DB_WAIT_RETRIES
 #         value: "30"
 #       - name: DB_WAIT_INTERVAL
 #         value: "2"
+#
+# Example 3 — invoke a shell script baked into the image (e.g. atlas migrations):
+#   migrationJob:
+#     enabled: true
+#     command:
+#       - /bin/sh
+#       - -c
+#       - /app/packages/repo/scripts/migrate-from-pod.sh
+#
+# Example 4 — direct binary, no shell wrapper (use args for flags):
+#   migrationJob:
+#     enabled: true
+#     command: ["/app/bin/migrate"]
+#     args: ["--config", "/app/config/migrate.yaml", "up"]
+#
+# Tip: anything you used to write inline in a standalone migrate-job.yaml under
+# kargo/env/<env>/migrate-job.yaml moves into `command` here. The `cd <path>`
+# pattern stays inside the `sh -c` string — no separate workingDir field needed.
+# ─────────────────────────────────────────────────────────────────────────────
 migrationJob:
   enabled: false
-  hook: PreSync
-  hookDeletePolicy: BeforeHookCreation
+  hook: PreSync                           # PreSync | Sync | PostSync | SyncFail
+  hookDeletePolicy: BeforeHookCreation    # BeforeHookCreation | HookSucceeded | HookFailed
+  # The command the migration container runs. REQUIRED when enabled=true.
+  # Use the `/bin/sh -c "<script>"` form when you need shell features (cd, &&, env expansion).
   command: []
+  # Optional args appended to command. Most teams put everything in `command` with sh -c
+  # and leave args empty.
   args: []
+  # Extra env vars (in addition to ConfigMap + ExternalSecret which are auto-mounted).
   env: []
+  # Extra envFrom sources (ConfigMap/Secret refs are added automatically when enabled).
   envFrom: []
+  # Extra annotations on the Job (merged with the argocd hook annotations).
   annotations: {}
-  backoffLimit: 2
-  ttlSecondsAfterFinished: 3600
-  restartPolicy: Never
-  # activeDeadlineSeconds: 600
+  backoffLimit: 2                         # how many times to retry before failing the Job
+  ttlSecondsAfterFinished: 3600           # auto-delete the Job 1h after completion
+  restartPolicy: Never                    # Never | OnFailure
+  # activeDeadlineSeconds: 600            # hard timeout — uncomment to cap migration runtime
   resources:
     requests:
       cpu: 100m

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -755,6 +755,43 @@ cronJob:
   resources: {}
   podAnnotations: {}
 
+# Migration Job configuration (ArgoCD PreSync hook)
+# Runs a one-time Job before the Deployment is updated — typically for DB migrations.
+# Uses the same image as the main deployment. ConfigMap and ExternalSecret are
+# automatically mounted via envFrom when enabled.
+# Example:
+#   migrationJob:
+#     enabled: true
+#     command:
+#       - /bin/sh
+#       - -c
+#       - npm run migrate
+#     env:
+#       - name: DB_WAIT_RETRIES
+#         value: "30"
+#       - name: DB_WAIT_INTERVAL
+#         value: "2"
+migrationJob:
+  enabled: false
+  hook: PreSync
+  hookDeletePolicy: BeforeHookCreation
+  command: []
+  args: []
+  env: []
+  envFrom: []
+  annotations: {}
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 3600
+  restartPolicy: Never
+  # activeDeadlineSeconds: 600
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 # StatefulSet configuration (only used when workloadType: statefulset)
 statefulSet:
   # Service name for the StatefulSet (required for stable network identity)


### PR DESCRIPTION
Adds a new migrationJob section to the og-application chart that renders a Kubernetes Job with ArgoCD PreSync hook for running DB migrations before deployments. The Job uses the same image, serviceAccount, and security contexts as the main deployment, and automatically mounts ConfigMap and ExternalSecret via envFrom.

This replaces the need for standalone migrate-job.yaml files in each environment — teams just set migrationJob.enabled: true in values.yaml with their migration command.

Made-with: Cursor