### PR TITLE
Add sidecar injection annotation to values.yaml

### DIFF
--- a/charts/og-application/Chart.yaml
+++ b/charts/og-application/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 maintainers:
   - name: XOPS Platform Team

--- a/charts/og-application/values.yaml
+++ b/charts/og-application/values.yaml
@@ -71,6 +71,7 @@ serviceAccount:
 
 deploymentAnnotations:
   reloader.stakater.com/auto: "true"
+  sidecar.signadot.com/inject: "true"
 
 deploymentStrategy:
   type: RollingUpdate


### PR DESCRIPTION
This pull request makes a small configuration change to the `charts/og-application/values.yaml` file by adding a new deployment annotation.

* Added the `sidecar.signadot.com/inject: "true"` annotation to `deploymentAnnotations`, enabling automatic injection of the Signadot sidecar.