### PR TITLE
[CLOUD-6785] feat(og-application): add annotations knob across all templates (1.0.14)

### DIFF
--- a/charts/og-application/Chart.yaml
+++ b/charts/og-application/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.0.13
+version: 1.0.14
 
 
 maintainers:

--- a/charts/og-application/templates/configmap.yaml
+++ b/charts/og-application/templates/configmap.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "og-application.fullname" . }}-cm
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   {{- toYaml .Values.configMap.data | nindent 2 }}
 {{- end }}

--- a/charts/og-application/templates/cronjob.yaml
+++ b/charts/og-application/templates/cronjob.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "og-application.fullname" . }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.cronJob.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   schedule: {{ .Values.cronJob.schedule | quote }}
   concurrencyPolicy: {{ .Values.cronJob.concurrencyPolicy | default "Forbid" }}

--- a/charts/og-application/templates/externalsecret.yaml
+++ b/charts/og-application/templates/externalsecret.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "og-application.fullname" . }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.externalSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   refreshInterval: {{ .Values.externalSecret.refreshInterval }}
   secretStoreRef:
@@ -48,6 +52,10 @@ metadata:
   name: {{ .name }}
   labels:
     {{- include "og-application.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   refreshInterval: {{ .refreshInterval | default "1h" }}
   secretStoreRef:

--- a/charts/og-application/templates/hpa.yaml
+++ b/charts/og-application/templates/hpa.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "og-application.fullname" . }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/og-application/templates/namespace.yaml
+++ b/charts/og-application/templates/namespace.yaml
@@ -5,4 +5,8 @@ metadata:
   name: {{ .Values.namespace.name | default .Release.Namespace }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.namespace.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/og-application/templates/networkpolicy.yaml
+++ b/charts/og-application/templates/networkpolicy.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "og-application.fullname" . }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.networkPolicy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/og-application/templates/pdb.yaml
+++ b/charts/og-application/templates/pdb.yaml
@@ -6,6 +6,10 @@ metadata:
   name: {{ include "og-application.fullname" . }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.podDisruptionBudget.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   selector:

--- a/charts/og-application/templates/secretstore.yaml
+++ b/charts/og-application/templates/secretstore.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ .Values.secretStore.name | default (printf "%s-secret-store" (include "og-application.fullname" .)) }}
   labels:
     {{- include "og-application.labels" . | nindent 4 }}
+  {{- with .Values.secretStore.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   provider:
     {{- if .Values.secretStore.provider.aws }}


### PR DESCRIPTION
## Summary

Audited every template in `og-application` for a values-driven `annotations` passthrough on resource metadata. Found **6 missing** and added them in the same shape as the existing patterns. Net: every Kubernetes resource the chart emits now accepts `<key>.annotations` from values.yaml, so consumers can drive any annotation (ArgoCD `sync-wave`, prometheus scrape hints, custom domain controllers, etc.) without forking the chart.

The original motivation was the new `migrationJob` (chart 1.0.13, PR #110) — it's effectively unusable on a fresh sync because consumers can't reorder `ConfigMap` / `ExternalSecret` via sync-wave annotations. See **chicken-and-egg** section below.

### Inventory after this PR

| Resource | Values knob | Status |
|---|---|---|
| ServiceAccount | `serviceAccount.annotations` | pre-existing |
| migrationJob | `migrationJob.annotations` | pre-existing |
| AgentgatewayPolicy | `agentgatewayPolicy.annotations` | pre-existing |
| HTTPRoute (primary + looped) | `httproute.annotations`, `httproutes[].annotations` | pre-existing |
| Ingress | `ingress.annotations` | pre-existing |
| Service | `service.annotations` | pre-existing |
| Deployment / StatefulSet | `deploymentAnnotations` | pre-existing |
| **ConfigMap** | `configMap.annotations` | **added** |
| **ExternalSecret (primary + looped)** | `externalSecret.annotations`, `externalSecrets[].annotations` | **added** |
| **CronJob** | `cronJob.annotations` | **added** |
| **HorizontalPodAutoscaler** | `autoscaling.annotations` | **added** |
| **PodDisruptionBudget** | `podDisruptionBudget.annotations` | **added** |
| **Namespace** | `namespace.annotations` | **added** |
| **NetworkPolicy** | `networkPolicy.annotations` | **added** |
| **SecretStore** | `secretStore.annotations` | **added** |

### The chicken-and-egg this unblocks

Observed live on `platform-int-eks-gary-repo-v3-integration`:

| `migrationJob.hook` | Why it fails on a fresh Application sync |
|---|---|
| `PreSync` (chart default) | Job runs before SA/CM/ES are applied → pod can't mount its SA, can't resolve `envFrom` (CM + ExternalSecret) → Pending forever → ArgoCD hangs on `waiting for completion of hook batch/Job/<svc>-og-application-migrate`. |
| `PostSync` | Workload pod can't reach `Healthy` without schema → Deployment never `Healthy` → PostSync never fires → same hang. |
| `Sync` + Job-only sync-wave | CM/ES default to wave 0 → no values-only way to put them earlier than the Job → Job pod still can't resolve `envFrom`. |

### How consumers use it once 1.0.14 ships

```yaml
serviceAccount:
  annotations:
    argocd.argoproj.io/sync-wave: "-10"
configMap:
  annotations:
    argocd.argoproj.io/sync-wave: "-10"
externalSecret:
  annotations:
    argocd.argoproj.io/sync-wave: "-10"
migrationJob:
  hook: Sync
  annotations:
    argocd.argoproj.io/sync-wave: "-5"
```

Sync phase order on every sync (including the first):
1. **wave -10**: SA + CM + ES applied
2. **wave -5**: Sync-hook Job runs (envFrom resolved, SA mounted; `BeforeHookCreation` cleans the prior Job on re-runs)
3. **wave 0**: Deployment + Service apply against the new schema

Workload pod never sees an old/empty schema, migrate runs once per sync (not per pod restart like an init container), no chicken-and-egg.

### Backwards-compatibility — all knobs optional

Every new knob uses the existing pattern `{{- with .Values.X.annotations }}`. When the values key is absent, the entire `annotations:` block is omitted from the rendered resource — **no breaking change** for existing values.yaml files. Verified by rendering a minimal values.yaml: `helm lint` clean and the rendered resources contain no `annotations` field on any of the 9 touched resources.

### Verification

```bash
# Minimal values (no annotations set anywhere)
helm lint charts/og-application -f minimal.yaml          # 0 failures
helm template testapp charts/og-application -f minimal.yaml \
  | grep -B1 'annotations:'                              # only migrationJob's own hardcoded ArgoCD annotations

# All knobs populated with test/origin: <name>
helm template testapp charts/og-application -f all-knobs.yaml \
  | grep test/origin | sort -u                           # 11 distinct lines, one per knob
```

Bumps chart `1.0.13` → `1.0.14`.

## Test plan

- [ ] CI lint passes
- [ ] After merge: push 1.0.14 to ECR (`helm-charts/og-application`)
- [ ] Bump pin in hackathon IssueOps generator (engops repo) — generator updated to emit the four sync-wave annotations on its generated values.yaml
- [ ] Re-trigger gary-repo-v3 sync on the new chart pin → confirm sync completes cleanly with migrate Job running between deps and Deployment