### PR TITLE
[CLOUD-6768] sha pinning with renovate based approach

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["action"],
+      "excludePackagePrefixes": ["OpenGov/"],
+      "pinDigests": true
+    },
+    {
+      "matchDepTypes": ["action"],
+      "excludePackagePrefixes": ["OpenGov/"],
+      "matchUpdateTypes": ["pinDigest"],
+      "addLabels": ["renovate-pin-digest"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
   ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to improve the handling of GitHub Actions dependencies. The main changes introduce specific rules for pinning and automerging digest updates for action dependencies, while excluding those from the `OpenGov/` namespace.

Dependency management improvements:

* Added `packageRules` to pin digests for dependencies of type `action`, except those with the `OpenGov/` prefix.
* Configured Renovate to automatically label, automerge, and use platform automerge for digest pin updates on action dependencies (excluding `OpenGov/`), streamlining updates and reducing manual intervention.