### PR TITLE
PRO-13791: Add HTTPRoute and AgentgatewayPolicy templates for Gateway API migration

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.6.7
+version: 4.7.0
 
 
 maintainers:

--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.0
+version: 4.6.8
 
 
 maintainers:

--- a/charts/application-core/templates/agentgatewaypolicy.yaml
+++ b/charts/application-core/templates/agentgatewaypolicy.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- if or .Values.httpRoute.cors.enabled .Values.httpRoute.requestTimeout -}}
+{{- $fullName := include "application-core.fullname" . -}}
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "application-core.labels" . | nindent 4 }}
+  annotations:
+    {{- include "application-core.annotations" $ | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ $fullName }}
+  traffic:
+    {{- if .Values.httpRoute.cors.enabled }}
+    cors:
+      allowCredentials: {{ .Values.httpRoute.cors.allowCredentials | default false }}
+      {{- with .Values.httpRoute.cors.allowOrigins }}
+      allowOrigins:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.httpRoute.cors.allowHeaders }}
+      allowHeaders:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.httpRoute.cors.allowMethods }}
+      allowMethods:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.httpRoute.cors.maxAge }}
+      maxAge: {{ . }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.httpRoute.requestTimeout }}
+    timeouts:
+      request: {{ .Values.httpRoute.requestTimeout | quote }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/application-core/templates/agentgatewaypolicy.yaml
+++ b/charts/application-core/templates/agentgatewaypolicy.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.httpRoute.enabled -}}
-{{- if or .Values.httpRoute.cors.enabled .Values.httpRoute.requestTimeout -}}
+{{- $hasCors := or .Values.httpRoute.cors.allowOrigins .Values.httpRoute.cors.allowHeaders .Values.httpRoute.cors.allowMethods .Values.httpRoute.cors.allowCredentials -}}
+{{- if or $hasCors .Values.httpRoute.requestTimeout -}}
 {{- $fullName := include "application-core.fullname" . -}}
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
@@ -15,9 +16,11 @@ spec:
       kind: HTTPRoute
       name: {{ $fullName }}
   traffic:
-    {{- if .Values.httpRoute.cors.enabled }}
+    {{- if $hasCors }}
     cors:
-      allowCredentials: {{ .Values.httpRoute.cors.allowCredentials | default false }}
+      {{- if .Values.httpRoute.cors.allowCredentials }}
+      allowCredentials: {{ .Values.httpRoute.cors.allowCredentials }}
+      {{- end }}
       {{- with .Values.httpRoute.cors.allowOrigins }}
       allowOrigins:
         {{- range . }}

--- a/charts/application-core/templates/httproute.yaml
+++ b/charts/application-core/templates/httproute.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "application-core.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "application-core.labels" . | nindent 4 }}
+  annotations:
+    {{- include "application-core.annotations" $ | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- range .Values.httpRoute.parentRefs }}
+    - name: {{ .name }}
+      {{- if .namespace }}
+      namespace: {{ .namespace }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName }}
+      {{- end }}
+    {{- end }}
+  {{- if .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.httpRoute.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .Values.httpRoute.rules }}
+    {{- toYaml .Values.httpRoute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      {{- with .Values.httpRoute.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -181,12 +181,18 @@ ingressPreview:
 # Example 1: Simple service (only HTTPRoute, no policy)
 #   httpRoute:
 #     enabled: true
+#     parentRefs:
+#       - name: procurement-gateway
+#         namespace: agentgateway-system
 #     hostnames:
 #       - procurement.ogintegration.us
 #
 # Example 2: Service with CORS (HTTPRoute + AgentgatewayPolicy)
 #   httpRoute:
 #     enabled: true
+#     parentRefs:
+#       - name: procurement-gateway
+#         namespace: agentgateway-system
 #     hostnames:
 #       - api.procurement.ogintegration.us
 #     cors:
@@ -201,6 +207,9 @@ ingressPreview:
 # Example 3: Path-based routing (shared hostname, custom rules)
 #   httpRoute:
 #     enabled: true
+#     parentRefs:
+#       - name: procurement-gateway
+#         namespace: agentgateway-system
 #     hostnames:
 #       - api.procurement.ogintegration.us
 #     rules:
@@ -215,6 +224,9 @@ ingressPreview:
 # Example 4: Long timeout (websocket/streaming, HTTPRoute + AgentgatewayPolicy)
 #   httpRoute:
 #     enabled: true
+#     parentRefs:
+#       - name: procurement-gateway
+#         namespace: agentgateway-system
 #     hostnames:
 #       - sync.procurement.ogintegration.us
 #     requestTimeout: "3600s"
@@ -222,6 +234,9 @@ ingressPreview:
 # Example 5: Full AgentgatewayPolicy (CORS + timeout combined)
 #   httpRoute:
 #     enabled: true
+#     parentRefs:
+#       - name: procurement-gateway
+#         namespace: agentgateway-system
 #     hostnames:
 #       - contract-doc-sync.procurement.ogintegration.us
 #     requestTimeout: "3600s"

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -269,9 +269,13 @@ ingressPreview:
 #
 httpRoute:
   enabled: false
-  parentRefs:
-    - name: procurement-gateway
-      namespace: agentgateway-system
+  # parentRefs specifies which Gateway this HTTPRoute attaches to.
+  # Must be set per service — no default since Gateway name varies by team.
+  # Example:
+  #   parentRefs:
+  #     - name: procurement-gateway
+  #       namespace: agentgateway-system
+  parentRefs: []
   hostnames: []
   annotations: {}
   # Override rules for custom path routing; if omitted, defaults to

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -171,6 +171,30 @@ ingressPreview:
   #    hosts:
   #      - preview-chart-example.local
 
+# HTTPRoute for Gateway API (AgentGateway migration from NGINX Ingress).
+# Deploys an HTTPRoute resource that attaches to the procurement Gateway.
+# Used alongside or as a replacement for the Ingress resource above.
+httpRoute:
+  enabled: false
+  parentRefs:
+    - name: procurement-gateway
+      namespace: agentgateway-system
+  hostnames: []
+  annotations: {}
+  # Override rules for custom path routing; if omitted, defaults to
+  # PathPrefix "/" -> service fullname:service.port
+  rules: []
+  timeouts: {}
+  # Request timeout for AgentgatewayPolicy (e.g., "60s", "3600s")
+  requestTimeout: ""
+  cors:
+    enabled: false
+    allowCredentials: false
+    allowOrigins: []
+    allowHeaders: []
+    allowMethods: []
+    maxAge: null
+
 configMap:
   enabled: false
   data: {}

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -174,6 +174,52 @@ ingressPreview:
 # HTTPRoute for Gateway API (AgentGateway migration from NGINX Ingress).
 # Deploys an HTTPRoute resource that attaches to the procurement Gateway.
 # Used alongside or as a replacement for the Ingress resource above.
+#
+# When httpRoute.enabled is true, an HTTPRoute is always created.
+# An AgentgatewayPolicy is ONLY created when cors.enabled or requestTimeout is set.
+#
+# Example 1: Simple service (only HTTPRoute, no policy)
+#   httpRoute:
+#     enabled: true
+#     hostnames:
+#       - procurement.ogintegration.us
+#
+# Example 2: Service with CORS (HTTPRoute + AgentgatewayPolicy)
+#   httpRoute:
+#     enabled: true
+#     hostnames:
+#       - api.procurement.ogintegration.us
+#     cors:
+#       enabled: true
+#       allowCredentials: true
+#       allowOrigins:
+#         - https://procurement.ogintegration.us
+#       allowHeaders:
+#         - Content-Type
+#         - Authorization
+#         - traceparent
+#
+# Example 3: Path-based routing (shared hostname, custom rules)
+#   httpRoute:
+#     enabled: true
+#     hostnames:
+#       - api.procurement.ogintegration.us
+#     rules:
+#       - matches:
+#           - path:
+#               type: PathPrefix
+#               value: /api/v1/search
+#         backendRefs:
+#           - name: pro-search-service
+#             port: 4001
+#
+# Example 4: Long timeout (websocket/streaming, HTTPRoute + AgentgatewayPolicy)
+#   httpRoute:
+#     enabled: true
+#     hostnames:
+#       - sync.procurement.ogintegration.us
+#     requestTimeout: "3600s"
+#
 httpRoute:
   enabled: false
   parentRefs:

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -176,7 +176,7 @@ ingressPreview:
 # Used alongside or as a replacement for the Ingress resource above.
 #
 # When httpRoute.enabled is true, an HTTPRoute is always created.
-# An AgentgatewayPolicy is ONLY created when cors.enabled or requestTimeout is set.
+# An AgentgatewayPolicy is ONLY created when any CORS config (allowOrigins, allowHeaders, etc.) or requestTimeout is provided.
 #
 # Example 1: Simple service (only HTTPRoute, no policy)
 #   httpRoute:
@@ -190,7 +190,6 @@ ingressPreview:
 #     hostnames:
 #       - api.procurement.ogintegration.us
 #     cors:
-#       enabled: true
 #       allowCredentials: true
 #       allowOrigins:
 #         - https://procurement.ogintegration.us
@@ -227,7 +226,6 @@ ingressPreview:
 #       - contract-doc-sync.procurement.ogintegration.us
 #     requestTimeout: "3600s"
 #     cors:
-#       enabled: true
 #       allowCredentials: true
 #       allowOrigins:
 #         - https://procurement.ogintegration.us
@@ -283,7 +281,6 @@ httpRoute:
   # Request timeout for AgentgatewayPolicy (e.g., "60s", "3600s")
   requestTimeout: ""
   cors:
-    enabled: false
     allowCredentials: false
     allowOrigins: []
     allowHeaders: []

--- a/charts/application-core/values.yaml
+++ b/charts/application-core/values.yaml
@@ -220,6 +220,55 @@ ingressPreview:
 #       - sync.procurement.ogintegration.us
 #     requestTimeout: "3600s"
 #
+# Example 5: Full AgentgatewayPolicy (CORS + timeout combined)
+#   httpRoute:
+#     enabled: true
+#     hostnames:
+#       - contract-doc-sync.procurement.ogintegration.us
+#     requestTimeout: "3600s"
+#     cors:
+#       enabled: true
+#       allowCredentials: true
+#       allowOrigins:
+#         - https://procurement.ogintegration.us
+#         - https://assets.procurement.opengov.com
+#       allowHeaders:
+#         - DNT
+#         - Keep-Alive
+#         - User-Agent
+#         - X-Requested-With
+#         - If-Modified-Since
+#         - Cache-Control
+#         - Content-Type
+#         - Range
+#         - Authorization
+#         - traceparent
+#       allowMethods:
+#         - GET
+#         - POST
+#         - PUT
+#         - DELETE
+#         - OPTIONS
+#       maxAge: 86400
+#
+# This generates an AgentgatewayPolicy resource:
+#   apiVersion: agentgateway.dev/v1alpha1
+#   kind: AgentgatewayPolicy
+#   spec:
+#     targetRefs:
+#       - group: gateway.networking.k8s.io
+#         kind: HTTPRoute
+#         name: <service-name>
+#     traffic:
+#       cors:
+#         allowCredentials: true
+#         allowOrigins: [...]
+#         allowHeaders: [...]
+#         allowMethods: [...]
+#         maxAge: 86400
+#       timeouts:
+#         request: "3600s"
+#
 httpRoute:
   enabled: false
   parentRefs:


### PR DESCRIPTION
## Summary

- Add `httproute.yaml` template — creates a Gateway API HTTPRoute when `httpRoute.enabled: true`
- Add `agentgatewaypolicy.yaml` template — creates an AgentgatewayPolicy for CORS and timeouts (only rendered when CORS or requestTimeout is configured)
- Add `httpRoute` defaults to `values.yaml` with parentRef pointing to `procurement-gateway` in `agentgateway-system`
- Bump chart version from 4.6.7 → 4.7.0

## Jira

[PRO-13791](https://opengovinc.atlassian.net/browse/PRO-13791)

## Context

Part of the NGINX→AgentGateway migration. This chart is shared by both procurement and utility-billing teams. The new templates allow services to create HTTPRoutes by adding `httpRoute.enabled: true` to their values files — same pattern as the existing `ingress.enabled` flag.

Both Ingress and HTTPRoute can coexist during migration. Services enable HTTPRoute first, validate via port-forward, then ALB is cut over from NGINX to Envoy.

## Validation

```
helm template test charts/application-core/ --set httpRoute.enabled=true --set "httpRoute.hostnames[0]=api.dev.example.com"
helm template test charts/application-core/ --set httpRoute.enabled=true --set httpRoute.cors.enabled=true --set "httpRoute.cors.allowOrigins[0]=https://example.com"
helm lint charts/application-core/
```

All tests pass:
- [x] HTTPRoute renders with correct parentRef, hostname, backendRef
- [x] AgentgatewayPolicy renders only when CORS or timeout is configured
- [x] AgentgatewayPolicy not rendered when no CORS/timeout (simple services)
- [x] Default values (httpRoute.enabled: false) — no HTTPRoute rendered
- [x] `helm lint` passes
- [x] Existing Ingress template unaffected

[PRO-13791]: https://opengovinc.atlassian.net/browse/PRO-13791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ