### PR TITLE
PRO-14120: Rename AgentgatewayPolicy → TrafficPolicy for kgateway v2.3.1

### DIFF
--- a/charts/application-core/Chart.yaml
+++ b/charts/application-core/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.6.8
+version: 4.6.9
 
 
 maintainers:

--- a/charts/application-core/templates/trafficpolicy.yaml
+++ b/charts/application-core/templates/trafficpolicy.yaml
@@ -2,8 +2,8 @@
 {{- $hasCors := or .Values.httpRoute.cors.allowOrigins .Values.httpRoute.cors.allowHeaders .Values.httpRoute.cors.allowMethods .Values.httpRoute.cors.allowCredentials -}}
 {{- if or $hasCors .Values.httpRoute.requestTimeout -}}
 {{- $fullName := include "application-core.fullname" . -}}
-apiVersion: agentgateway.dev/v1alpha1
-kind: AgentgatewayPolicy
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
 metadata:
   name: {{ $fullName }}
   labels:


### PR DESCRIPTION
## Summary

- Rename `agentgatewaypolicy.yaml` → `trafficpolicy.yaml`
- Update `apiVersion: agentgateway.dev/v1alpha1` → `gateway.kgateway.dev/v1alpha1`
- Update `kind: AgentgatewayPolicy` → `TrafficPolicy`
- Bump chart version to `4.6.9`

The agentgateway project was renamed to kgateway in v2.3.0. CRD API groups and resource kinds changed. This chart update is needed before upgrading the kgateway controller from v2.2.1 to v2.3.1.

**Why:** kgateway v2.3.1 fixes a CORS preflight bug where `access-control-allow-credentials` header was missing from OPTIONS responses. This bug caused the integration cutover rollback.

## Jira

[PRO-14120](https://opengovinc.atlassian.net/browse/PRO-14120)

## Test plan

- [ ] `helm lint` passes ✅
- [ ] `helm template` renders `TrafficPolicy` with correct apiVersion ✅
- [ ] After publishing, services using `httpRoute.cors` should create `TrafficPolicy` instead of `AgentgatewayPolicy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PRO-14120]: https://opengovinc.atlassian.net/browse/PRO-14120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ