### PR TITLE
[CLOUD-7084] fix(og-application): make ingress host optional for path-based routing

### DIFF
--- a/charts/og-application/Chart.yaml
+++ b/charts/og-application/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 1.0.14
+version: 1.0.15
 
 
 maintainers:

--- a/charts/og-application/templates/ingress.yaml
+++ b/charts/og-application/templates/ingress.yaml
@@ -28,7 +28,9 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
## Summary

- **CLOUD-7084**: The `ingress.yaml` template always emitted `host: {{ .host | quote }}` with no conditional, making it impossible to create host-less (path-based) Ingress rules
- Wraps the `host:` field in `{{- if .host }}...{{- end }}` so it is only rendered when the value is non-empty
- Bumps chart version `1.0.14` → `1.0.15`

## Root cause

`org-registry-service` needed path-based ingress routing. Because the template forced a hostname, PR #7277 worked around it by setting `host: controlpanel.opengov.com`, which hijacked that hostname and caused the **2026-06-29 ingress hostname hijack incident**.

## What changed

**`templates/ingress.yaml`** — one `if` block around the `host:` line:

```diff
-    - host: {{ .host | quote }}
-      http:
+    - {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
+      http:
```

## Impact on existing deployments

**Zero.** All current deployments that use `ingress.enabled: true` pass a real non-empty hostname (e.g. `tenant-forge.opengov.com`, `gab-green-donut.ogintegration.us`). The `if .host` condition is truthy for all of them — rendered output is identical to before.

The fix only activates when `host: ""` is set, which no existing deployment does.

## Usage after this fix

```yaml
# Path-based routing (new capability — no hostname binding)
ingress:
  enabled: true
  hosts:
    - host: ""   # leave empty for host-less routing
      paths:
        - path: /registry
          pathType: ImplementationSpecific

# Host-based routing (unchanged behavior)
ingress:
  enabled: true
  hosts:
    - host: "app.example.com"
      paths:
        - path: /
          pathType: ImplementationSpecific
```

## Test plan

- [ ] `helm template` with `host: "app.example.com"` renders `host:` field as before
- [ ] `helm template` with `host: ""` renders a host-less Ingress rule (no `host:` field in rules)
- [ ] Existing deployments (tenant-forge, demo-forge, gab, hcm-app) unaffected — no re-deploy needed

Fixes [CLOUD-7084](https://opengovinc.atlassian.net/browse/CLOUD-7084)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CLOUD-7084]: https://opengovinc.atlassian.net/browse/CLOUD-7084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ