### PR TITLE
[CLOUD-7248] ci: migrate workflows to ARC self-hosted runner

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   lint-test:
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-platform
     steps:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-platform
     steps:
       - name: Checkout
         uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2


### PR DESCRIPTION
## Summary
Migrate GitHub Actions workflows from `ubuntu-latest` GitHub-hosted runners to `gha-runner-scale-set-platform` (ARC self-hosted runner, PLATFORM team).

## Why
- **CLOUD-7187**: Org-wide migration from GitHub-hosted to self-hosted ARC scale-set runners
- Self-hosted runners reduce cost and give the PLATFORM team dedicated, predictable capacity

## Changes
Updated `runs-on: ubuntu-latest` → `runs-on: gha-runner-scale-set-platform` in 2 workflow file(s):

- `.github/workflows/release-charts.yaml`
- `.github/workflows/lint-test.yaml`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)